### PR TITLE
Multiple packages enhancement

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,10 @@ $ smp -h
   Merge package.xml
 
   Options:
-
-    -h, --help                   output usage information
-    -V, --version                output the version number
-    -p, --packages               path to the packages.xml
-    -o, --output                 path where to output the merged package.xml
+    -V, --version              output the version number
+    -p, --packages [paths...]  paths to the package.xml files (default: [])
+    -o, --output [path]        path where to output the merged package.xml (default: "./package.xml")
+    -h, --help                 display help for command
 ```
 
 ### Module

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ $ smp -h
     -o, --output [path]        path where to output the merged package.xml (default: "./package.xml")
     -h, --help                 display help for command
 ```
+### Example use:
+```sh
+smp -p ./package1.xml ./package2.xml -o ./combined-package.xml
+```
 
 ### Module
 

--- a/bin/smp
+++ b/bin/smp
@@ -8,10 +8,10 @@ const pjson = require('../package.json');
 program
   .description(pjson.description)
   .version(pjson.version)
-  .option('-p, --packages [path]', 'path to the packages.xml', (v,m)=>{m.push(v);return m;},[])
+  .option('-p, --packages [paths...]', 'paths to the package.xml files', [])
   .option('-o, --output [path]', 'path where to output the merged package.xml', './package.xml')
   .parse(process.argv);
-orchestrator(program, console.log)
+orchestrator(program.opts(), console.log)
 .catch(function(err){
   console.log(err);
 });

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const asyncXmlParser = require('./lib/utils/async-xml-parser');
 module.exports = (config,logger) => {
 
   // Check if we have a non-empty list of packages
-  if(typeof config.packages === 'undefined' || config.packages === null || config.packages === []) {
+  if(!Array.isArray(config.packages) || config.packages.length === 0) {
     throw new Error('List of package.xml files can not be empty');
   }
 

--- a/index.js
+++ b/index.js
@@ -7,9 +7,9 @@ const asyncXmlParser = require('./lib/utils/async-xml-parser');
 // Plugin to merge package.xml.
 module.exports = (config,logger) => {
 
-  // Check if we have enough config options
-  if(typeof config.packages === 'undefined' || config.packages === null) {
-    throw new Error('Not enough config options');
+  // Check if we have a non-empty list of packages
+  if(typeof config.packages === 'undefined' || config.packages === null || config.packages === []) {
+    throw new Error('List of package.xml files can not be empty');
   }
 
   // The module return this promise

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "Sébastien Colladon <colladonsebastien@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "commander": "^2.9.0",
+    "commander": "^9.4.0",
     "npm": "^6.0.1",
     "xml2js": "^0.4.17",
     "xmlbuilder": "^10.0.0"


### PR DESCRIPTION
Hey all,
I've changed the `-p` flag to accept a list of files in a more intuitive way by making it a [variadic option](https://github.com/tj/commander.js#variadic-option). Most CLI applications usually behave this way.

Before, you had to write the `-p` flag before every single file you wanted to package:
```sh
smp -p ./package1.xml -p ./package2.xml -p ./package3.xml -o ./combined-package.xml
```

Now you only have to write the `-p` flag once and then provide a list of files:
```sh
smp -p ./package1.xml ./package2.xml ./package3.xml -o ./combined-package.xml
```

This is also backwards compatible with the old way of doing things as shown in the examples in `tj/commander` in the link I've provided above.
I've also updated the `README.md` to reflect these changes.